### PR TITLE
Proposed fix for CPANTESTER fail report.

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -57,6 +57,7 @@ Math::Random             = 0.72
 Storable                 = 2.51
 Parallel::ForkManager    = 1.19
 PerlIO::gzip             = 0.19
+List::Util               = 1.44
 
 [Prereqs / TestRequires]
 Test::Most               = 0.35


### PR DESCRIPTION
Hi,

Please review the PR as it proposed fix to the following CPANTESTER fail report by upgrading to List::Util v1.44 minimum.

https://www.cpantesters.org/cpan/report/bf84a894-b7fa-11e8-8fb1-ef5133556b3f

Many Thanks
Best Regards,
Mohammad S Anwar